### PR TITLE
通知機能を修正

### DIFF
--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -17,7 +17,7 @@ class LinebotController < ApplicationController
         type: 'text',
         text: text
        }
-    response = client.push_message(user.line_id, message)
+    @response = client.push_message(user.line_id, message)
   end
 
   def callback
@@ -39,7 +39,7 @@ class LinebotController < ApplicationController
 
           # ここからレスポンス組立
           text = event.message['text']
-          response = ''
+          @response = ''
 
           # 0が送られたら、常にトップに戻る
           @user.top! if text.eql?('0') || text.eql?('０')
@@ -49,23 +49,23 @@ class LinebotController < ApplicationController
           when 'top'
             case text
             when '0', '０'
-              response += "中止だね！\n"
+              @response += "中止だね！\n"
             when '1', '１' # ゴミ登録
-              response +=  <<~EOS
+              @response +=  <<~EOS
                 ゴミの登録だね！
                 何のゴミを登録する？一つだけ答えてね！
                 (例)燃えるゴミ
               EOS
               @user.registration!
             when '2', '２' # 登録してあるゴミの一覧表示
-              response +=  <<~EOS
+              @response +=  <<~EOS
                 登録内容の確認だね！
                 今登録している内容は以下の通りだよ！
                 #{@user.show_trashes}
               EOS
 
             when '3', '３' # 内容編集
-              response +=  <<~EOS
+              @response +=  <<~EOS
                 登録内容の編集だね！
                 どれを編集する？
                 #{@user.show_editable_trashes}
@@ -73,7 +73,7 @@ class LinebotController < ApplicationController
               @user.which_trash_to_edit!
 
             when '4', '４' # 次回確認
-              response += "次回のゴミ収集日は、
+              @response += "次回のゴミ収集日は、
                 燃えるゴミ
                 毎週
                 月曜日・木曜日
@@ -81,13 +81,13 @@ class LinebotController < ApplicationController
               当日の朝6時に通知するからね！
               \n"
             else
-              response += "正しく入力してね！\n"
+              @response += "正しく入力してね！\n"
             end
           ### 登録モード ###
           when 'registration'
             @user.messages.create!(text: text) # ユーザーの返信内容をDBへ保存
 
-            response +=  <<~EOS
+            @response +=  <<~EOS
               「#{text}」を登録するね！
               収集日はいつかな？
                 1: 月曜日
@@ -107,7 +107,7 @@ class LinebotController < ApplicationController
               @user.messages.create!(text: text) # ユーザーの返信内容をDBへ保存
               trash_name = @user.messages[-2].text
 
-              response +=  <<~EOS
+              @response +=  <<~EOS
                 次に、「#{trash_name}」の周期を教えてね！
                   1: 毎週
                   2: 隔週
@@ -118,7 +118,7 @@ class LinebotController < ApplicationController
 
               @user.add_cycle!
             else
-              response += "正しく入力してね！\n"
+              @response += "正しく入力してね！\n"
             end
           when 'add_cycle'
             if text =~ /^[1-4]$/
@@ -132,20 +132,20 @@ class LinebotController < ApplicationController
 
               @trash = @user.trashes.create!(name: trash_name, cycle: cycle, collection_days: [collection_day])
 
-              response +=  <<~EOS
+              @response +=  <<~EOS
                 「#{@trash.name}」の収集日は「#{@trash.cycle.name_i18n}」の「#{collection_day.day_of_week_i18n}」だね！
                 登録したよ！
               EOS
               @user.top!
             else
-              response += "正しく入力してね！\n"
+              @response += "正しく入力してね！\n"
             end
           ### 編集モード ###
           when 'which_trash_to_edit'
             @user.messages.create!(text: text) # ユーザーの返信内容をDBへ保存
             trash = @user.trashes[text.to_i - 1] #=> ユーザーが選択したゴミ
 
-            response +=  <<~EOS
+            @response +=  <<~EOS
               「#{trash.name}」が選択されたよ！
               どの項目を編集する？
                 1: 収集物の名前
@@ -157,40 +157,44 @@ class LinebotController < ApplicationController
             @user.which_item_to_edit!
 
           when 'which_item_to_edit'
-            @user.messages.create!(text: text) # ユーザーの返信内容をDBへ保存
-            items = ['ゴミの名前', '周期', '曜日']
-            item = items[text.to_i - 1] #=> ユーザーが選択した項目
-            response +=  "変更するのは「#{item}」だね！\n"
+            if text =~ /^([1-3]|[１-３])$/
+              @user.messages.create!(text: text) # ユーザーの返信内容をDBへ保存
+              items = ['ゴミの名前', '周期', '曜日']
+              item = items[text.to_i - 1] #=> ユーザーが選択した項目
+              @response +=  "変更するのは「#{item}」だね！\n"
 
-            case item
-            when 'ゴミの名前'
-              response +=  <<~EOS
-                どんな名前にする？（例）燃えないゴミ
-              EOS
-            when '周期'
-              response +=  <<~EOS
-                周期をどれに変更する？
-                  1: 毎週
-                  2: 隔週
-                  3: 第１・３
-                  4: 第２・４
-                  0: やめる
-              EOS
-            when '曜日'
-              response +=  <<~EOS
-                収集日をいつに変更する？
-                  1: 月曜日
-                  2: 火曜日
-                  3: 水曜日
-                  4: 木曜日
-                  5: 金曜日
-                  6: 土曜日
-                  7: 日曜日
-                  0: やめる
-              EOS
+              case item
+              when 'ゴミの名前'
+                @response +=  <<~EOS
+                  どんな名前にする？（例）燃えないゴミ
+                EOS
+              when '周期'
+                @response +=  <<~EOS
+                  周期をどれに変更する？
+                    1: 毎週
+                    2: 隔週
+                    3: 第１・３
+                    4: 第２・４
+                    0: やめる
+                EOS
+              when '曜日'
+                @response +=  <<~EOS
+                  収集日をいつに変更する？
+                    1: 月曜日
+                    2: 火曜日
+                    3: 水曜日
+                    4: 木曜日
+                    5: 金曜日
+                    6: 土曜日
+                    7: 日曜日
+                    0: やめる
+                EOS
+              end
+
+              @user.edit_complete!
+            else
+              @response += "正しく入力してね！\n"
             end
-
-            @user.edit_complete!
 
           when 'edit_complete'
             # 変更対象のゴミのインスタンス @trash を決定する
@@ -205,27 +209,39 @@ class LinebotController < ApplicationController
             case item
             when 'ゴミの名前'
               @trash.update!(name: text)
+              edit_complete
             when '周期'
-              @trash.latest_collection_day.update!(cycle: text.to_i)
+              if text =~ /^[1-4]$/
+                @trash.cycle.update!(name: text.to_i)
+                edit_complete
+              else
+                @response += "正しく入力してね！\n"
+              end
             when '曜日'
-              @trash.latest_collection_day.update!(day_of_week: text.to_i)
+              if text =~ /^[1-7]$/
+                @trash.latest_collection_day.update!(day_of_week: text.to_i)
+                edit_complete
+              else
+                @response += "正しく入力してね！\n"
+              end
             end
 
-            response += <<~EOS
-              編集完了したよ！
-              新しい登録内容は、
-                #{@trash.name}
-                #{@trash.cycle.name_i18n}
-                #{@trash.latest_collection_day.day_of_week_i18n}
-              だよ！\n
-            EOS
-
-            @user.top!
+            def edit_complete
+              @response += <<~EOS
+                編集完了したよ！
+                新しい登録内容は、
+                  #{@trash.name}
+                  #{@trash.cycle.name_i18n}
+                  #{@trash.latest_collection_day.day_of_week_i18n}
+                だよ！\n
+              EOS
+              @user.top!
+            end
           end
 
           if @user.top?
             # モード選択を問う
-            response +=  <<~EOS
+            @response +=  <<~EOS
                 =============================
                 次はどうする？
                 ↓↓番号を選択↓↓
@@ -236,10 +252,10 @@ class LinebotController < ApplicationController
             EOS
           end
 
-          # responseを組み立てた結果を返す
+          # @responseを組み立てた結果を返す
           message = {
             type: 'text',
-            text: response
+            text: @response
           }
           client.reply_message(event['replyToken'], message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video

--- a/app/models/collection_day.rb
+++ b/app/models/collection_day.rb
@@ -1,5 +1,6 @@
 class CollectionDay < ApplicationRecord
-  has_many :trashes
+  has_many :trash_collection_days
+  has_many :trashes, through: :trash_collection_days
 
   enum day_of_week: {
     monday: 1,

--- a/app/models/collection_day.rb
+++ b/app/models/collection_day.rb
@@ -1,5 +1,5 @@
 class CollectionDay < ApplicationRecord
-  belongs_to :trash
+  has_many :trashes
 
   enum day_of_week: {
     monday: 1,

--- a/app/models/collection_day.rb
+++ b/app/models/collection_day.rb
@@ -11,13 +11,6 @@ class CollectionDay < ApplicationRecord
     sunday: 7,
   }
 
-  enum cycle: {
-    every_week: 1, # 毎週
-    every_other_week: 2, # 隔週
-    first_and_third: 3, # 第一・三
-    second_and_fourth: 4, # 第二・四
-  }
-
   def user
     trash.user
   end

--- a/app/models/cycle.rb
+++ b/app/models/cycle.rb
@@ -1,5 +1,5 @@
 class Cycle < ApplicationRecord
-  belongs_to :trash
+  has_one :trash
 
   enum name: {
     every_week: 1, # 毎週

--- a/app/models/cycle.rb
+++ b/app/models/cycle.rb
@@ -3,7 +3,8 @@ class Cycle < ApplicationRecord
 
   enum name: {
     every_week: 1, # 毎週
-    first_and_third: 2, # 第1・3
-    second_and_fourth: 3, # 第2・4
+    every_other_week: 2, # 隔週
+    first_and_third: 3, # 第1・3
+    second_and_fourth: 4, # 第2・4
   }
 end

--- a/app/models/cycle.rb
+++ b/app/models/cycle.rb
@@ -1,0 +1,9 @@
+class Cycle < ApplicationRecord
+  belongs_to :trash
+
+  enum name: {
+    every_week: 1, # 毎週
+    first_and_third: 2, # 第1・3
+    second_and_fourth: 3, # 第2・4
+  }
+end

--- a/app/models/cycle.rb
+++ b/app/models/cycle.rb
@@ -3,8 +3,9 @@ class Cycle < ApplicationRecord
 
   enum name: {
     every_week: 1, # 毎週
-    every_other_week: 2, # 隔週
-    first_and_third: 3, # 第1・3
-    second_and_fourth: 4, # 第2・4
+    odd_weeks: 2, # 奇数週
+    even_weeks: 3, # 偶数週
+    first_and_third: 4, # 第1・3
+    second_and_fourth: 5, # 第2・4
   }
 end

--- a/app/models/trash.rb
+++ b/app/models/trash.rb
@@ -1,7 +1,8 @@
 class Trash < ApplicationRecord
   belongs_to :user
-  belongs_to :collection_day
   belongs_to :cycle
+  has_many :trash_collection_days
+  has_many :collection_days, through: :trash_collection_days
 
   def latest_collection_day
     collection_days.order(created_at: :desc).first

--- a/app/models/trash.rb
+++ b/app/models/trash.rb
@@ -1,7 +1,7 @@
 class Trash < ApplicationRecord
   belongs_to :user
-  has_many :collection_days, dependent: :destroy
-  has_one :cycle
+  belongs_to :collection_day
+  belongs_to :cycle
 
   def latest_collection_day
     collection_days.order(created_at: :desc).first

--- a/app/models/trash.rb
+++ b/app/models/trash.rb
@@ -10,15 +10,19 @@ class Trash < ApplicationRecord
   scope :search_with_cycle, ->(cycle) { where(cycles: { name: cycle }) }
   scope :search_with_user, ->(user) { where(user_id: user.id) }
   scope :throw_away, -> (nansyu, youbi) do
-    # 隔週は一旦無し
     searching_cycles = case nansyu
     when 1, 3
       [:every_week, :first_and_third]
     when 2, 4
       [:every_week, :second_and_fourth]
     else
-      :every_week
+      [:every_week]
     end
+    ## 隔週のゴミを追加する
+    # 今日の週番号
+    now_week_num = Date.today.strftime('%W').to_i
+    # 奇数ならodd_weeksを、そうでないならeven_weeksを追加する
+    searching_cycles << (now_week_num.even? ? :even_weeks : :odd_weeks)
 
     with_collection_days.search_with_youbi(youbi).with_cycle.search_with_cycle(searching_cycles)
   end

--- a/app/models/trash.rb
+++ b/app/models/trash.rb
@@ -1,6 +1,7 @@
 class Trash < ApplicationRecord
   belongs_to :user
   has_many :collection_days, dependent: :destroy
+  has_one :cycle
 
   def latest_collection_day
     collection_days.order(created_at: :desc).first

--- a/app/models/trash.rb
+++ b/app/models/trash.rb
@@ -4,6 +4,25 @@ class Trash < ApplicationRecord
   has_many :trash_collection_days
   has_many :collection_days, through: :trash_collection_days
 
+  scope :with_collection_days, -> { joins(:collection_days) }
+  scope :with_cycle, -> { joins(:cycle) }
+  scope :search_with_youbi, ->(youbi) { where(collection_days: { day_of_week: youbi }) }
+  scope :search_with_cycle, ->(cycle) { where(cycles: { name: cycle }) }
+  scope :search_with_user, ->(user) { where(user_id: user.id) }
+  scope :throw_away, -> (nansyu, youbi) do
+    # 隔週は一旦無し
+    searching_cycles = case nansyu
+    when 1, 3
+      [:every_week, :first_and_third]
+    when 2, 4
+      [:every_week, :second_and_fourth]
+    else
+      :every_week
+    end
+
+    with_collection_days.search_with_youbi(youbi).with_cycle.search_with_cycle(searching_cycles)
+  end
+
   def latest_collection_day
     collection_days.order(created_at: :desc).first
   end

--- a/app/models/trash_collection_day.rb
+++ b/app/models/trash_collection_day.rb
@@ -1,0 +1,4 @@
+class TrashCollectionDay < ApplicationRecord
+  belongs_to :trash
+  belongs_to :collection_day
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@ class User < ApplicationRecord
     trashes.map do |trash|
       [
         trash.name,
-        trash.latest_collection_day.cycle_i18n,
+        trash.cycle.name_i18n,
         trash.latest_collection_day.day_of_week_i18n
       ]
     end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,7 +9,8 @@ ja:
         friday: 金曜日
         saturday: 土曜日
         sunday: 日曜日
-      cycle:
+    cycle:
+      name:
         every_week: 毎週
         every_other_week: 隔週
         first_and_third: 第1・3

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,7 @@
 ja:
+  errors:
+    messages:
+      record_invalid: "バリデーションに失敗しました: %{errors}"
   enums:
     collection_day:
       day_of_week:
@@ -12,6 +15,7 @@ ja:
     cycle:
       name:
         every_week: 毎週
-        every_other_week: 隔週
+        odd_weeks: 隔週(奇数週)
+        even_weeks: 隔週(偶数週)
         first_and_third: 第1・3
         second_and_fourth: 第2・4

--- a/db/migrate/20211112013315_create_cycles.rb
+++ b/db/migrate/20211112013315_create_cycles.rb
@@ -1,0 +1,10 @@
+class CreateCycles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :cycles do |t|
+      t.references :trash, null: false, foreign_key: true
+      t.integer :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211112013657_remove_cycle_from_collection_days.rb
+++ b/db/migrate/20211112013657_remove_cycle_from_collection_days.rb
@@ -1,0 +1,5 @@
+class RemoveCycleFromCollectionDays < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :collection_days, :cycle, :integer
+  end
+end

--- a/db/migrate/20211113015728_remove_trash_id_from_cycles.rb
+++ b/db/migrate/20211113015728_remove_trash_id_from_cycles.rb
@@ -1,0 +1,5 @@
+class RemoveTrashIdFromCycles < ActiveRecord::Migration[6.1]
+  def change
+    remove_reference :cycles, :trash, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20211113015950_add_cycle_id_to_trashes.rb
+++ b/db/migrate/20211113015950_add_cycle_id_to_trashes.rb
@@ -1,0 +1,5 @@
+class AddCycleIdToTrashes < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :trashes, :cycle, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20211113021423_remove_trash_id_from_collection_days.rb
+++ b/db/migrate/20211113021423_remove_trash_id_from_collection_days.rb
@@ -1,0 +1,5 @@
+class RemoveTrashIdFromCollectionDays < ActiveRecord::Migration[6.1]
+  def change
+    remove_reference :collection_days, :trash, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20211113021513_add_collection_day_id_to_trash.rb
+++ b/db/migrate/20211113021513_add_collection_day_id_to_trash.rb
@@ -1,0 +1,5 @@
+class AddCollectionDayIdToTrash < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :trashes, :collection_day, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20211114002628_remove_collection_day_id_from_trashes.rb
+++ b/db/migrate/20211114002628_remove_collection_day_id_from_trashes.rb
@@ -1,0 +1,5 @@
+class RemoveCollectionDayIdFromTrashes < ActiveRecord::Migration[6.1]
+  def change
+    remove_reference :trashes, :collection_day, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20211114003543_create_trash_collection_days.rb
+++ b/db/migrate/20211114003543_create_trash_collection_days.rb
@@ -1,0 +1,10 @@
+class CreateTrashCollectionDays < ActiveRecord::Migration[6.1]
+  def change
+    create_table :trash_collection_days do |t|
+      t.references :trash, null: false, foreign_key: true
+      t.references :collection_day, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_13_021513) do
+ActiveRecord::Schema.define(version: 2021_11_14_003543) do
 
   create_table "collection_days", force: :cascade do |t|
     t.integer "day_of_week"
@@ -32,14 +32,21 @@ ActiveRecord::Schema.define(version: 2021_11_13_021513) do
     t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
+  create_table "trash_collection_days", force: :cascade do |t|
+    t.integer "trash_id", null: false
+    t.integer "collection_day_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["collection_day_id"], name: "index_trash_collection_days_on_collection_day_id"
+    t.index ["trash_id"], name: "index_trash_collection_days_on_trash_id"
+  end
+
   create_table "trashes", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "user_id", null: false
     t.integer "cycle_id", null: false
-    t.integer "collection_day_id", null: false
-    t.index ["collection_day_id"], name: "index_trashes_on_collection_day_id"
     t.index ["cycle_id"], name: "index_trashes_on_cycle_id"
     t.index ["user_id"], name: "index_trashes_on_user_id"
   end
@@ -52,7 +59,8 @@ ActiveRecord::Schema.define(version: 2021_11_13_021513) do
   end
 
   add_foreign_key "messages", "users"
-  add_foreign_key "trashes", "collection_days"
+  add_foreign_key "trash_collection_days", "collection_days"
+  add_foreign_key "trash_collection_days", "trashes"
   add_foreign_key "trashes", "cycles"
   add_foreign_key "trashes", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_03_012529) do
+ActiveRecord::Schema.define(version: 2021_11_12_013657) do
 
   create_table "collection_days", force: :cascade do |t|
     t.integer "day_of_week"
     t.integer "trash_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "cycle"
     t.index ["trash_id"], name: "index_collection_days_on_trash_id"
+  end
+
+  create_table "cycles", force: :cascade do |t|
+    t.integer "trash_id", null: false
+    t.integer "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["trash_id"], name: "index_cycles_on_trash_id"
   end
 
   create_table "messages", force: :cascade do |t|
@@ -45,6 +52,7 @@ ActiveRecord::Schema.define(version: 2021_11_03_012529) do
   end
 
   add_foreign_key "collection_days", "trashes"
+  add_foreign_key "cycles", "trashes"
   add_foreign_key "messages", "users"
   add_foreign_key "trashes", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,22 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_12_013657) do
+ActiveRecord::Schema.define(version: 2021_11_13_021513) do
 
   create_table "collection_days", force: :cascade do |t|
     t.integer "day_of_week"
-    t.integer "trash_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["trash_id"], name: "index_collection_days_on_trash_id"
   end
 
   create_table "cycles", force: :cascade do |t|
-    t.integer "trash_id", null: false
     t.integer "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["trash_id"], name: "index_cycles_on_trash_id"
   end
 
   create_table "messages", force: :cascade do |t|
@@ -41,6 +37,10 @@ ActiveRecord::Schema.define(version: 2021_11_12_013657) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "user_id", null: false
+    t.integer "cycle_id", null: false
+    t.integer "collection_day_id", null: false
+    t.index ["collection_day_id"], name: "index_trashes_on_collection_day_id"
+    t.index ["cycle_id"], name: "index_trashes_on_cycle_id"
     t.index ["user_id"], name: "index_trashes_on_user_id"
   end
 
@@ -51,8 +51,8 @@ ActiveRecord::Schema.define(version: 2021_11_12_013657) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  add_foreign_key "collection_days", "trashes"
-  add_foreign_key "cycles", "trashes"
   add_foreign_key "messages", "users"
+  add_foreign_key "trashes", "collection_days"
+  add_foreign_key "trashes", "cycles"
   add_foreign_key "trashes", "users"
 end


### PR DESCRIPTION
- Cycleモデルを追加
  - TrashとCycleに1対1関連付けを追加
- TrashとCollectionDayの関連付けを多対多に変更
- 周期に隔週を追加
  - Cycleモデルのnameカラムに'odd_weeks'と'even_weeks'を追加
- 通知機能を修正
  - 捨てるゴミの数だけ通知メッセージが送られてくるバグを修正
  - 隔週に設定したゴミも通知できるように修正