### PR TITLE
ゴミ登録時のバグを修正

### DIFF
--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -112,8 +112,7 @@ class LinebotController < ApplicationController
               @response += "正しく入力してね！\n"
             end
           when 'add_cycle'
-            # TODO: 1-5に変更する
-            if text =~ /^[1-4]$/
+            if text =~ /^[1-5]$/
               @user.messages.create!(text: text)
               trash_name = @user.messages[-3].text
               # TODO: メソッドにする => @user.choose_day_of_week
@@ -128,9 +127,6 @@ class LinebotController < ApplicationController
                            when '5' then :second_and_fourth
                            end
               cycle = Cycle.find_by(name: cycle_name)
-              # FIXME: cycle=5を選ぶと、バリデーションに失敗する.
-              #   ActiveRecord::RecordInvalid (バリデーションに失敗しました: Cycle translation missing:
-              #   ja.activerecord.errors.models.trash.attributes.cycle.required):
               @trash = @user.trashes.create!(name: trash_name, cycle: cycle, collection_days: [collection_day])
 
               @response += <<~TEXT
@@ -231,8 +227,7 @@ class LinebotController < ApplicationController
               @trash.update!(name: text)
               edit_complete.call
             when '周期'
-              # TODO: 1-5に変更する
-              if text =~ /^[1-4]$/
+              if text =~ /^[1-5]$/
                 # 周期の決定
                 now_week_num = Time.zone.today.strftime('%W').to_i
                 cycle_name = case text
@@ -242,9 +237,6 @@ class LinebotController < ApplicationController
                              when '4' then :first_and_third
                              when '5' then :second_and_fourth
                              end
-                # FIXME: cycle=5を選ぶと、バリデーションに失敗する.
-                #   ActiveRecord::RecordInvalid (バリデーションに失敗しました: Cycle translation missing:
-                #   ja.activerecord.errors.models.trash.attributes.cycle.required):
                 @trash.cycle.update!(name: cycle_name)
                 edit_complete.call
               else

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,6 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+# 共通データの読み込み
+require Rails.root.join('db/seeds/common.rb')
+
+# # 環境ファイル読み込み
+path = Rails.root.join("db/seeds/#{Rails.env}.rb")
+require path if  File.exist?(path)

--- a/db/seeds/common.rb
+++ b/db/seeds/common.rb
@@ -1,0 +1,2 @@
+(1..5).each { |n| Cycle.create!(name: n) }
+(1..7).each { |n| CollectionDay.create!(day_of_week: n) }

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -1,0 +1,13 @@
+user = User.create!(
+  line_id: ENV['MY_LINE_ID'],
+)
+day_str = %w[nil 月 火 水 木 金 土 日]
+cycle_str = %w[nil 毎週 奇数隔週 偶数隔週 第1・3 第2・4]
+
+(1..5).each do |cycle_num|
+	cycle = Cycle.find(cycle_num)
+  (1..7).each do |day_num|
+		day = CollectionDay.find(day_num)
+		Trash.create!(name: "#{cycle_str[cycle_num]}:#{day_str[day_num]}曜日のゴミ", user: user, cycle: cycle, collection_days: [day])
+  end
+end


### PR DESCRIPTION
- ゴミ登録時、周期で5を選ぶとエラーになるバグを修正
  - Cycleの初期データがないことが原因であった
- seedsファイルを作成し、初期データを自動で投入するよう変更